### PR TITLE
Terraform v0.13 support and format adjustments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,10 @@
+data "alicloud_account" "current_account" {}
+
 provider "alicloud" {
   version              = ">=1.56.0"
   region               = var.region != "" ? var.region : null
   configuration_source = "terraform-alicloud-modules/remote-backend"
+  profile              = "default"
 }
 
 locals {
@@ -36,10 +39,11 @@ resource "alicloud_oss_bucket" "this" {
 
 # OTS table store to lock state during applies
 resource "alicloud_ots_instance" "this" {
-  count       = var.create_ots_lock_instance ? 1 : 0
-  name        = local.lock_table_instance
-  description = "Terraform remote backend state lock."
-  accessed_by = "Any"
+  count         = var.create_ots_lock_instance ? 1 : 0
+  name          = local.lock_table_instance
+  description   = "Terraform remote backend state lock."
+  accessed_by   = "Any"
+  instance_type = var.backend_ots_lock_instance_type
   tags = {
     Purpose = "Terraform state lock for state in ${local.bucket_name}:${var.state_path}/${var.state_name}"
   }
@@ -52,7 +56,7 @@ resource "alicloud_ots_table" "this" {
   table_name    = local.lock_table_name
   time_to_live  = -1
   primary_key {
-    name = "init"
+    name = "LockID"
     type = "String"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -68,19 +68,19 @@ resource "alicloud_ots_table" "this" {
 */
 resource "local_file" "this" {
   content = <<EOF
-    terraform {
-      backend "oss" {
-        profile             = "default"
-        bucket              = "${local.bucket_name}"
-        prefix              = "${var.state_path}"
-        key                 = "${var.state_name}"
-        acl                 = "${var.state_acl}"
-        region              = "${local.default_region}"
-        encrypt             = "${var.encrypt_state}"
-        tablestore_endpoint = "${local.lock_table_endpoint}"
-        tablestore_table    = "${local.lock_table_name}"
-      }
-    }
+terraform {
+  backend "oss" {
+    profile             = "default"
+    bucket              = "${local.bucket_name}"
+    prefix              = "${var.state_path}"
+    key                 = "${var.state_name}"
+    acl                 = "${var.state_acl}"
+    region              = "${local.default_region}"
+    encrypt             = "${var.encrypt_state}"
+    tablestore_endpoint = "${local.lock_table_endpoint}"
+    tablestore_table    = "${local.lock_table_name}"
+  }
+}
     EOF
 
   filename = "${path.root}/terraform.tf"

--- a/main.tf
+++ b/main.tf
@@ -9,12 +9,12 @@ provider "alicloud" {
 
 locals {
   default_bucket_name     = "terraform-remote-backend-${random_uuid.this.result}"
-  default_lock_table_name = replace("terraform-remote-backend-lock-table-${random_uuid.this.result}", "-", "_")
+  default_lock_table_name = "terraform-remote-backend-lock-table-${random_uuid.this.result}"
   default_lock_instance   = "tf-oss-backend"
   default_region          = var.region != "" ? var.region : data.alicloud_regions.this.ids.0
   bucket_name             = var.backend_oss_bucket != "" ? var.backend_oss_bucket : local.default_bucket_name
   lock_table_instance     = var.backend_ots_lock_instance != "" ? var.backend_ots_lock_instance : local.default_lock_instance
-  lock_table_name         = var.backend_ots_lock_table != "" ? var.backend_ots_lock_table : local.default_lock_table_name
+  lock_table_name         = replace(var.backend_ots_lock_table != "" ? var.backend_ots_lock_table : local.default_lock_table_name, "-", "_")
   lock_table_endpoint     = "https://${local.lock_table_instance}.${local.default_region}.ots.aliyuncs.com"
 
 }
@@ -70,6 +70,7 @@ resource "local_file" "this" {
   content = <<EOF
     terraform {
       backend "oss" {
+        profile             = "default"
         bucket              = "${local.bucket_name}"
         prefix              = "${var.state_path}"
         key                 = "${var.state_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "backend_ots_lock_instance" {
   default     = "tf-oss-backend"
 }
 
+variable "backend_ots_lock_instance_type" {
+  description = "The type for Tablestore (Capacity or HighPerformance)"
+  default     = "HighPerformance"
+}
+
 variable "create_ots_lock_table" {
   default     = false
   description = "Boolean:  If you have a ots table already, use that one, else make this true and one will be created"
@@ -21,6 +26,7 @@ variable "backend_ots_lock_table" {
   description = "OTS table to hold state lock when updating. If not set, the module will craete one with prefix `terraform-remote-backend`"
   default     = ""
 }
+
 variable "create_backend_bucket" {
   default     = false
   description = "Boolean.  If you have a OSS bucket already, use that one, else make this true and one will be created"


### PR DESCRIPTION
This PR should solve the #3 as it's happened to us also.
Variable `backend_ots_lock_instance_type` added because some region have different availability on the instance type. 

There's a slight spaces adjustment on the generated `local_file` too.